### PR TITLE
Initial cut at etcd quorum guard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY manifests /manifests
+LABEL io.k8s.display-name="OpenShift etcd-quorum-guard" \
+      io.k8s.description="This is a component of OpenShift and ensures quorum is maintained on etcd." \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,0 +1,4 @@
+FROM registry.svc.ci.openshift.org/openshift/ocp/v4.0:base
+COPY manifests /manifests
+LABEL io.k8s.display-name="OpenShift etcd-quorum-guard" \
+      io.k8s.description="This is a component of OpenShift and ensures quorum is maintained on etcd." \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# etcd Quorum Guard
+
+The etcd Quorum Guard ensures that quorum is maintained for etcd for
+[OpenShift](https://openshift.io/).
+
+For the etcd cluster to remain usable, we must maintain quorum, which
+is a majority of all etcd members.  For example, an etcd cluster with
+3 members (i.e. a 3 master deployment) must have at least 2 healthy
+etcd member to meet the quorum limit.
+
+There are situations where 2 etcd members could be down at once:
+
+* a master has gone offline and the MachineConfig Controller (MCC)
+  tries to rollout a new MachineConfig (MC) by rebooting masters
+* the MCC is doing a MachineConfig rollout and doesn't wait for the
+  etcd on the previous master to become healthy again before rebooting
+  the next master
+
+In short, we need a way to ensure that a drain on a master is not
+allowed to proceed if the reboot of the master would cause etcd quorum
+loss.
+
+The etcd quorum guard is implemented as a deployment, with one pod per
+master node.
+
+The etcd quorum guard checks the health of etcd by querying the health
+endpoint of etcd; if etcd reports itself unhealthy or is not present,
+the quorum guard reports itself not ready.  A disruption budget is
+used to allow no more than one unhealthy/missing quorum guard (and
+hence etcd).  If one etcd is already not healthy or missing, this
+disruption budget will act as a drain gate, not allowing an attempt to
+drain another node.
+
+This drain gate cannot protect against a second node failing due to
+e. g. hardware failure; it can only protect against an attempt to
+drain the node in preparation for taking it down.
+
+There is no user or administrator action necessary or available for
+the etcd Quorum Guard.

--- a/manifests/01-deployment.yaml
+++ b/manifests/01-deployment.yaml
@@ -69,12 +69,12 @@ spec:
             - -c
             - |
                 declare -r croot=/mnt/kube
-                declare -r health_endpoint="https://10.128.0.1:2379/health"
+                declare -r health_endpoint="https://etcd.kube-system.svc:2379/health"
                 declare -r cert="$(find $croot -name 'system:etcd-peer*.crt' -print)"
                 declare -r key="$(find $croot -name 'system:etcd-peer*.key' -print)"
                 declare -r cacert="$croot/ca.crt"
                 [[ -z $cert || -z $key ]] && exit 1
-                curl -k --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
+                curl --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
             initialDelaySecond: 5
             periodSecond: 5
         resources:

--- a/manifests/01-deployment.yaml
+++ b/manifests/01-deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-quorum-guard
+  namespace: kube-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: etcd-quorum-guard
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: etcd-quorum-guard
+        app: etcd-quorum-guard
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - "etcd-quorum-guard"
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+        operator: Exists
+      - key: node.kubernetes.io/memory-pressure
+        effect: NoSchedule
+        operator: Exists
+      - key: node.kubernetes.io/disk-pressure
+        effect: NoSchedule
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        effect: NoExecute
+        operator: Exists
+      - key: node.kubernetes.io/unreachable
+        effect: NoExecute
+        operator: Exists
+      - key: node.kubernetes.io/unschedulable
+        effect: NoExecute
+        operator: Exists
+      containers:
+      - image: registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+        imagePullPolicy: IfNotPresent
+        name: etcd-quorum-guard-container
+        volumeMounts:
+        - mountPath: /mnt/kube
+          name: kubecerts
+        command:
+        - "/bin/sleep"
+        args:
+        - "infinity"
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+                declare -r croot=/mnt/kube
+                declare -r health_endpoint="https://10.128.0.1:2379/health"
+                declare -r cert="$(find $croot -name 'system:etcd-peer*.crt' -print)"
+                declare -r key="$(find $croot -name 'system:etcd-peer*.key' -print)"
+                declare -r cacert="$croot/ca.crt"
+                [[ -z $cert || -z $key ]] && exit 1
+                curl -k --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
+            initialDelaySecond: 5
+            periodSecond: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 5Mi
+      volumes:
+      - name: kubecerts
+        hostPath:
+          path: /etc/kubernetes/static-pod-resources/etcd-member

--- a/manifests/01-deployment.yaml
+++ b/manifests/01-deployment.yaml
@@ -70,8 +70,8 @@ spec:
             - |
                 declare -r croot=/mnt/kube
                 declare -r health_endpoint="https://etcd.kube-system.svc:2379/health"
-                declare -r cert="$(find $croot -name 'system:etcd-peer*.crt' -print)"
-                declare -r key="$(find $croot -name 'system:etcd-peer*.key' -print)"
+                declare -r cert="$(find $croot -name 'system:etcd-peer*.crt' -print -quit)"
+                declare -r key="${cert%.crt}.key"
                 declare -r cacert="$croot/ca.crt"
                 [[ -z $cert || -z $key ]] && exit 1
                 curl --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'

--- a/manifests/02-disruption-budget.yaml
+++ b/manifests/02-disruption-budget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  namespace: kube-system
+  name: etcd-quorum-guard
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: etcd-quorum-guard


### PR DESCRIPTION
First cut at etcd quorum guard

Known limitations:
* ~~Hard codes the host IP address (pod-relative)~~
* Hard codes the number of instances (3 -- needs to be the number of masters)
* Hard codes the permitted number of failures (1 -- should be `floor((M-1)/2)`)
* No tests (not apparent how to test this outside of a running cluster)