### PR TITLE
Add 2-second timeout on probe, and use host network to use localhost for probe

### DIFF
--- a/manifests/01-deployment.yaml
+++ b/manifests/01-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         name: etcd-quorum-guard
         app: etcd-quorum-guard
     spec:
+      hostNetwork: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -69,12 +70,12 @@ spec:
             - -c
             - |
                 declare -r croot=/mnt/kube
-                declare -r health_endpoint="https://etcd.kube-system.svc:2379/health"
+                declare -r health_endpoint="https://127.0.0.1:2379/health"
                 declare -r cert="$(find $croot -name 'system:etcd-peer*.crt' -print -quit)"
                 declare -r key="${cert%.crt}.key"
                 declare -r cacert="$croot/ca.crt"
                 [[ -z $cert || -z $key ]] && exit 1
-                curl --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
+                curl --max-time 2 --silent --cert "${cert//:/\:}" --key "$key" --cacert "$cacert" "$health_endpoint" |grep '{ *"health" *: *"true" *}'
             initialDelaySecond: 5
             periodSecond: 5
         resources:


### PR DESCRIPTION
Using host networking allows use of localhost rather than servicename that must be looked up.
2-second timeout on health probe allows for quicker detection of failure if etcd is not responsive.
