### PR TITLE
Temporarily disable e2e test to allow release PR to merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(GOBINDATA_BIN):
 #	go get -u github.com/jteeuwen/go-bindata/...
 
 test-e2e: generate
-	go test -v ./test/e2e
+	go test -v ./test/e2e --count=1
 
 verify:	verify-gofmt
 


### PR DESCRIPTION
The release PR https://github.com/openshift/release/pull/3267 is currently blocked because its test is failing because the `etcd-quorum-guard` deployment is not present in the release image.  See e. g. https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_release/3267/rehearse-3267-pull-ci-openshift-etcd-quorum-guard-master-e2e-aws-operator/7.  That PR is what will pull the deployment into the release image, at which point we can re-enable the test.

Also fixed a few small bugs, including an occasional race condition when cordoning/uncordoning nodes.