### PR TITLE
Dockerfile.rhel7: remove trailing backslash

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
 FROM registry.svc.ci.openshift.org/openshift/ocp/v4.0:base
 COPY manifests /manifests
 LABEL io.k8s.display-name="OpenShift etcd-quorum-guard" \
-      io.k8s.description="This is a component of OpenShift and ensures quorum is maintained on etcd." \
+      io.k8s.description="This is a component of OpenShift and ensures quorum is maintained on etcd."


### PR DESCRIPTION
This has unfortunate consequences downstream when automation modifies the Dockerfile adding something at the end.